### PR TITLE
SwitchBinary CC to include payload length before assuming V2 support

### DIFF
--- a/cpp/src/command_classes/SwitchBinary.cpp
+++ b/cpp/src/command_classes/SwitchBinary.cpp
@@ -107,7 +107,7 @@ namespace OpenZWave
 					// data[1] => Switch state
 					if (Internal::VC::ValueBool* value = static_cast<Internal::VC::ValueBool*>(GetValue(_instance, ValueID_Index_SwitchBinary::Level)))
 					{
-						if (GetVersion() >= 2)
+						if (GetVersion() >= 2 && _length == 4)
 							value->SetTargetValue(_data[2] != 0, _data[3]);
 						value->OnValueRefreshed(_data[1] != 0);
 						value->Release();


### PR DESCRIPTION
Leviton DZ15S and maybe other switches that support Version 2, don't sent a V2 report.  This checks the payload length as well as target value. (the pattern currently used in Basic CC)